### PR TITLE
just added --user to pip install commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ endif
 
 ## Install Python Dependencies
 requirements: test_environment
-	pip install -U pip setuptools wheel
-	pip install -r requirements.txt
+	pip install -U --user pip setuptools wheel
+	pip install -r --user requirements.txt
 
 ## Build features
 features:
@@ -50,7 +50,7 @@ else
 endif
 		@echo ">>> New conda env created. Activate with:\nsource activate $(PROJECT_NAME)"
 else
-	@pip install -q virtualenv virtualenvwrapper
+	@pip install -q --user virtualenv virtualenvwrapper
 	@echo ">>> Installing virtualenvwrapper if not already intalled.\nMake sure the following lines are in shell startup file\n\
 	export WORKON_HOME=$$HOME/.virtualenvs\nexport PROJECT_HOME=$$HOME/Devel\nsource /usr/local/bin/virtualenvwrapper.sh\n"
 	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"


### PR DESCRIPTION
O _create_environment_ do cookiecutter no Makefile parte do pressuposto de que caso fores gerenciar um ambiente virtual via virtualenvwrapper e esse ainda não tenha sido instalado, terás que realizar os comandos que são fornecidos no próprio script:

`
Make sure the following lines are in shell startup file
export WORKON_HOME=$$HOME/.virtualenvs
export PROJECT_HOME=$$HOME/Devel
source /usr/local/bin/virtualenvwrapper.sh
`

Tentei fazer com que essas linhas ai de cima rodassem automaticamente no Makefile mas não rolou porque não consegui:
![screenshot](https://user-images.githubusercontent.com/25311070/47884677-73e48800-de10-11e8-8b05-d610ea53da16.png)

Minha intenção era, caso explicitamente pedindo pra instalar algum dessas bibliotecas com o sudo, pelo menos eu poderia automatizar o processo. Mas, mesmo assim, não rolou.